### PR TITLE
feat: return to the main, if user restart the app

### DIFF
--- a/App.js
+++ b/App.js
@@ -1,14 +1,22 @@
 import React from "react";
 import { Provider } from "react-redux";
+import { NavigationContainer } from "@react-navigation/native";
+import { createNativeStackNavigator } from "@react-navigation/native-stack";
 
 import "./src/config/api";
 import AppNavigator from "./src/navigations/AppNavigator";
 import { store } from "./src/features/store";
 
+const Stack = createNativeStackNavigator();
+
 export default function App() {
   return (
     <Provider store={store}>
-      <AppNavigator />
+      <NavigationContainer>
+        <Stack.Navigator>
+          <Stack.Screen options={{ headerShown: false }} name="AppNavigator" component={AppNavigator} />
+        </Stack.Navigator>
+      </NavigationContainer>
     </Provider>
   );
 }

--- a/src/components/GoogleMap.js
+++ b/src/components/GoogleMap.js
@@ -9,10 +9,10 @@ import { ERROR_MESSAGE } from "../constants/utils";
 import CustomPin from "./CustomPin";
 import {
   color,
+  height,
   horizontalScale,
   verticalScale,
-  windowHeight,
-  windowWidth,
+  width,
 } from "../config/globalStyles";
 
 export default function GoogleMap() {
@@ -87,8 +87,8 @@ const styles = StyleSheet.create({
     alignItems: "center",
   },
   map: {
-    height: windowHeight,
-    width: windowWidth,
+    height: height,
+    width: width,
   },
   getPinDataButton: {
     top: verticalScale(40),

--- a/src/components/MyPageProfile.js
+++ b/src/components/MyPageProfile.js
@@ -8,8 +8,7 @@ import openImagePicker from "../api/openImagePicker";
 import { color, horizontalScale, verticalScale, moderateScale } from "../config/globalStyles";
 
 export default function MyPageProfile() {
-  const image = useSelector(selectUser).image;
-  const nickname = useSelector(selectUser).nickname;
+  const { image, nickname } = useSelector(selectUser);
   const dispatch = useDispatch();
 
   async function changeImagePicker() {

--- a/src/components/SlideModal.js
+++ b/src/components/SlideModal.js
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from "react";
-import { StyleSheet, View, Text, Image, TouchableOpacity } from "react-native";
 import Modal from "react-native-modal";
+import { StyleSheet, View, Text, Image, TouchableOpacity } from "react-native";
 import { useDispatch, useSelector } from "react-redux";
 
 import { selectModalOn, turnOnOffModal } from "../features/modalVisibleSlice";

--- a/src/components/WithdrawalModal.js
+++ b/src/components/WithdrawalModal.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { useDispatch } from "react-redux"
-import { View, StyleSheet, Text, Image, TouchableOpacity, Modal } from "react-native";
+import { View, StyleSheet, Text, Image, TouchableOpacity, Modal, Alert } from "react-native";
 
 import { color } from "../config/globalStyles";
 import ModalContainer from "./shared/ModalContainer";

--- a/src/config/globalStyles.js
+++ b/src/config/globalStyles.js
@@ -1,8 +1,6 @@
 import { Dimensions } from "react-native";
 
 export const { width, height } = Dimensions.get("screen");
-export const windowHeight = Dimensions.get("window").height;
-export const windowWidth = Dimensions.get("window").width;
 
 const guideScale = Math.sqrt(width * height);
 const scale = Math.sqrt(width * height) / guideScale;

--- a/src/features/userSlice.js
+++ b/src/features/userSlice.js
@@ -6,6 +6,8 @@ import { API_SERVER_URL } from "@env";
 export const signinUser = createAsyncThunk("user/signinUserStatus", async (user) => {
   const { email } = user;
 
+  await SecureStore.setItemAsync("email", email);
+
   const response = await axios.post(`${API_SERVER_URL}/users/login`, { email });
 
   const { id, token, isOriginalMember, image, pushAlarmStatus, nickname } = response.data;
@@ -43,6 +45,8 @@ const userSlice = createSlice({
   reducers: {
     logoutUser: () => {
       SecureStore.deleteItemAsync("token");
+      SecureStore.deleteItemAsync("email");
+      SecureStore.deleteItemAsync("nickname");
 
       return initialState;
     },
@@ -59,15 +63,11 @@ const userSlice = createSlice({
   },
   extraReducers: {
     [signinUser.pending]: (state) => {
-      if (state.status === "idle") {
-        state.status = "pending";
-      }
+      state.status = "pending";
     },
     [signinUser.fulfilled]: (state, action) => {
-      if (state.status === "pending") {
-        state.info = action.payload.info;
-        state.status = "success";
-      }
+      state.status = "success";
+      state.info = action.payload.info;
     },
     [signinUser.rejected]: (state, action) => {
       state.error = action.error;

--- a/src/navigations/AppNavigator.js
+++ b/src/navigations/AppNavigator.js
@@ -1,21 +1,46 @@
-import React from "react";
+import React, { useEffect } from "react";
+import { useDispatch, useSelector } from "react-redux";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
-import { NavigationContainer } from "@react-navigation/native";
+import * as SecureStore from "expo-secure-store";
 
 import MainNavigator from "./MainNavigator";
 import NewAccountNavigator from "./NewAccountNavigator";
 import LoginScreen from "../screens/LoginScreen";
+import { selectUser, signinUser } from "../features/userSlice";
 
 const Stack = createNativeStackNavigator();
 
-export default function AppNavigator() {
+export default function AppNavigator({ navigation }) {
+  const dispatch = useDispatch();
+  const { nickname } = useSelector(selectUser);
+
+  useEffect(() => {
+    async function getUserInfo() {
+      try {
+        const email = await SecureStore.getItemAsync("email");
+
+        await dispatch(signinUser({ email }));
+
+        if (nickname) {
+          return navigation.replace("MainNavigator");
+        }
+
+        if (email) {
+          return navigation.replace("NewAccountNavigator");
+        }
+      } catch (err) {
+        console.log(err);
+      }
+    }
+
+    getUserInfo();
+  }, []);
+
   return (
-    <NavigationContainer>
-      <Stack.Navigator>
-        <Stack.Screen name="Login" component={LoginScreen} options={{ headerShown: false }} />
-        <Stack.Screen name="NewAccountNavigator" component={NewAccountNavigator} options={{ headerShown: false }} />
-        <Stack.Screen name="MainNavigator" component={MainNavigator} options={{ headerShown: false }} />
-      </Stack.Navigator>
-    </NavigationContainer>
+    <Stack.Navigator>
+      <Stack.Screen name="Login" component={LoginScreen} options={{ headerShown: false }} />
+      <Stack.Screen name="NewAccountNavigator" component={NewAccountNavigator} options={{ headerShown: false }} />
+      <Stack.Screen name="MainNavigator" component={MainNavigator} options={{ headerShown: false }} />
+    </Stack.Navigator>
   );
 }

--- a/src/navigations/MainNavigator.js
+++ b/src/navigations/MainNavigator.js
@@ -14,7 +14,7 @@ export default function MainNavigator({ navigation }) {
       <Stack.Screen options={{ headerShown: false }} name="Bottom" component={BottomTabNavigator} />
       <Stack.Screen options={{ headerShown: true }} name="더보기" component={MorePageScreen} />
       <Stack.Screen options={{ headerShown: true }} name="상세페이지" component={DetailPinScreen} />
-      <Stack.Screen options={{ headerShown: true }} name="setting" component={SettingScreen} />
+      <Stack.Screen options={{ headerShown: true }} name="Setting" component={SettingScreen} />
     </Stack.Navigator>
   );
 }

--- a/src/screens/LoginScreen.js
+++ b/src/screens/LoginScreen.js
@@ -11,15 +11,17 @@ import CustomButton from "../components/shared/CustomButton";
 
 export default function LoginScreen({ navigation }) {
   const isSuccess = useSelector((state) => state.user.status === "success");
-  const { isOriginalMember } = useSelector(selectUser);
-  const dispatch = useDispatch();
   const [errorMessage, setErrorMessage] = useState("");
+  const { isOriginalMember, nickname } = useSelector(selectUser);
+  const dispatch = useDispatch();
 
   useEffect(() => {
     if (isSuccess) {
-      isOriginalMember
-        ? navigation.replace("MainNavigator")
-        : navigation.replace("NewAccountNavigator");
+      if (!isOriginalMember || !nickname) {
+        return navigation.replace("NewAccountNavigator");
+      }
+
+      return navigation.replace("MainNavigator");
     }
   }, [isSuccess]);
 

--- a/src/screens/NewNicknameScreen.js
+++ b/src/screens/NewNicknameScreen.js
@@ -46,9 +46,11 @@ export default function NewNicknameScreen({ navigation }) {
     data.append("email", email);
     data.append("nickname", finalNickname);
 
-    const token = await SecureStore.getItemAsync("token");
-
     try {
+      const token = await SecureStore.getItemAsync("token");
+
+      await SecureStore.setItemAsync("nickname", finalNickname);
+
       const result = await axios.post(`${API_SERVER_URL}/users/signup`, data, {
         email,
         nickname: finalNickname,


### PR DESCRIPTION
앱 로그인 후 앱을 껐다가 다시 켰을 때 로그인화면이 아닌 메인으로 돌아가도록 기능을 추가했습니다.
secure storage에 이메일, 닉네임 정보를 담아서 다시 켰을 때 확인 후에 존재 유무에 따라 화면을 이동해주었습니다.

- 앱 로그인 후 계정 생성 페이지에서 앱을 껐다 켰을 때 : 다시 계정생성 화면으로 이동
- 앱 로그인 후 계정 생성까지 완료한 후 앱을 껐다 켰을 때 : 메인화면으로 이동
- 로그아웃 / 탈퇴했을 때 :  secure storage에 담긴 내용 삭제